### PR TITLE
fix: fixed pulgin issue

### DIFF
--- a/k8s/strapi-deployment.yaml
+++ b/k8s/strapi-deployment.yaml
@@ -63,11 +63,27 @@ spec:
         app: strapi
     spec:
       serviceAccountName: strapi-sa
+      initContainers:
+        - name: strapi-build
+          image: 325553860333.dkr.ecr.us-east-2.amazonaws.com/openobserve/strapi:latest
+          command: ["/bin/sh"]
+          args: ["-c", "npm run build && rm -rf /app/.cache"]
+          env:
+            - name: NODE_ENV
+              value: "production"
+          envFrom:
+            - secretRef:
+                name: strapi-env-secrets
       containers:
         - name: strapi
           image: 325553860333.dkr.ecr.us-east-2.amazonaws.com/openobserve/strapi:latest
           ports:
             - containerPort: 1337
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: STRAPI_DISABLE_UPDATE_NOTIFICATION
+              value: "true"
           envFrom:
             - secretRef:
                 name: strapi-env-secrets


### PR DESCRIPTION
1. Added explicit environment variables to ensure production mode
2. Added an init container that runs npm run build and clears cache before the main container starts

 This should fix the pluginOptions error by ensuring:
  - The admin panel is properly built for the EKS environment
  - Any cached data that might be causing conflicts is cleared
  - The content types are properly registered

 The init container will run firstl, and then main Strapi container will start with a clean, properly built state that matches database schema.