### PR TITLE
fix: use Recreate strategy for strapi deployment

### DIFF
--- a/k8s/strapi-deployment.yaml
+++ b/k8s/strapi-deployment.yaml
@@ -54,6 +54,9 @@ metadata:
     app: strapi
 spec:
   replicas: 1
+  # Recreate: strapi-pvc is RWO EBS; RollingUpdate deadlocks on Multi-Attach
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: strapi


### PR DESCRIPTION
## Summary
- Set `strategy: type: Recreate` on the strapi Deployment. `strapi-pvc` is a ReadWriteOnce EBS (gp3) volume, so the default RollingUpdate strategy deadlocks whenever a rollout schedules the new pod on a different node: the new pod is stuck in `Init` with a `Multi-Attach error` waiting for the volume, while the old pod won't terminate until the new pod is Ready.
- This happened on the o2cloud cluster today (2026-08-05); the live deployment was already patched with `kubectl patch`, so this PR just brings the manifest in line with the cluster to prevent regression if the deployment is ever recreated from this repo.

## Test plan
- [x] Live cluster already runs with `Recreate`; rollout completed and pod is `1/1 Running`
- [ ] Verify next image rollout completes without Multi-Attach errors