### PR TITLE
feat: add Event Hero Simple component for event landing pages

### DIFF
--- a/src/api/event-landing-page/content-types/event-landing-page/schema.json
+++ b/src/api/event-landing-page/content-types/event-landing-page/schema.json
@@ -25,6 +25,7 @@
       "type": "dynamiczone",
       "components": [
         "landing-page-component.event-dinner-hero",
+        "landing-page-component.event-hero-simple",
         "landing-page-component.about-section",
         "landing-page-component.whos-in-the-room",
         "landing-page-component.cta-banner",

--- a/src/components/landing-page-component/event-hero-simple.json
+++ b/src/components/landing-page-component/event-hero-simple.json
@@ -1,0 +1,53 @@
+{
+  "collectionName": "components_landing_page_component_event_hero_simples",
+  "info": {
+    "displayName": "Event Hero Simple",
+    "description": "Content-only hero for event pages: background, event information and CTA buttons (no video or image)"
+  },
+  "options": {},
+  "attributes": {
+    "sectionTag": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string"
+    },
+    "description": {
+      "type": "text"
+    },
+    "date": {
+      "type": "datetime"
+    },
+    "endDate": {
+      "type": "datetime"
+    },
+    "ctaButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "elements.button"
+    },
+    "secondaryButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "elements.button"
+    },
+    "backgroundImage": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images",
+        "files"
+      ]
+    },
+    "backgroundColor": {
+      "type": "string"
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1086,6 +1086,28 @@ export interface LandingPageComponentEventDinnerHero
   };
 }
 
+export interface LandingPageComponentEventHeroSimple
+  extends Struct.ComponentSchema {
+  collectionName: 'components_landing_page_component_event_hero_simples';
+  info: {
+    description: 'Content-only hero for event pages: background, event information and CTA buttons (no video or image)';
+    displayName: 'Event Hero Simple';
+  };
+  attributes: {
+    backgroundColor: Schema.Attribute.String;
+    backgroundImage: Schema.Attribute.Media<'images' | 'files'>;
+    ctaButton: Schema.Attribute.Component<'elements.button', false>;
+    date: Schema.Attribute.DateTime;
+    description: Schema.Attribute.Text;
+    endDate: Schema.Attribute.DateTime;
+    format: Schema.Attribute.String;
+    location: Schema.Attribute.String;
+    secondaryButton: Schema.Attribute.Component<'elements.button', false>;
+    sectionTag: Schema.Attribute.String;
+    title: Schema.Attribute.String;
+  };
+}
+
 export interface LandingPageComponentEventMapSection
   extends Struct.ComponentSchema {
   collectionName: 'components_landing_page_component_event_map_sections';
@@ -2385,6 +2407,7 @@ declare module '@strapi/strapi' {
       'landing-page-component.cta-banner': LandingPageComponentCtaBanner;
       'landing-page-component.eligibility-requirements': LandingPageComponentEligibilityRequirements;
       'landing-page-component.event-dinner-hero': LandingPageComponentEventDinnerHero;
+      'landing-page-component.event-hero-simple': LandingPageComponentEventHeroSimple;
       'landing-page-component.event-map-section': LandingPageComponentEventMapSection;
       'landing-page-component.feature-cards': LandingPageComponentFeatureCards;
       'landing-page-component.feature-comparison': LandingPageComponentFeatureComparison;


### PR DESCRIPTION
Adds a content-only hero variant (background, event info, CTA buttons) alongside the existing Event Dinner Hero, which keeps the video/image column used by the Boston event page.