### PR TITLE
feat(hero-v3): add tech badges, CTA buttons and hero media fields

### DIFF
--- a/src/components/landing-page-component/hero-v3.json
+++ b/src/components/landing-page-component/hero-v3.json
@@ -12,6 +12,21 @@
     "description": {
       "type": "text"
     },
+    "techBadges": {
+      "type": "component",
+      "repeatable": true,
+      "component": "elements.button-with-icon"
+    },
+    "primaryButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "elements.button"
+    },
+    "secondaryButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "elements.button"
+    },
     "trustedCompanies": {
       "type": "component",
       "repeatable": true,
@@ -21,6 +36,15 @@
       "type": "component",
       "repeatable": true,
       "component": "elements.compare-item"
+    },
+    "media": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos"
+      ],
+      "type": "media",
+      "multiple": false
     },
     "formsectionHeading": {
       "type": "component",

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1221,6 +1221,10 @@ export interface LandingPageComponentHeroV3 extends Struct.ComponentSchema {
     features: Schema.Attribute.Component<'elements.compare-item', true>;
     formButtonText: Schema.Attribute.Component<'elements.button', false>;
     formsectionHeading: Schema.Attribute.Component<'elements.heading', false>;
+    media: Schema.Attribute.Media<'images' | 'files' | 'videos'>;
+    primaryButton: Schema.Attribute.Component<'elements.button', false>;
+    secondaryButton: Schema.Attribute.Component<'elements.button', false>;
+    techBadges: Schema.Attribute.Component<'elements.button-with-icon', true>;
     title: Schema.Attribute.String;
     trustedCompanies: Schema.Attribute.Component<'elements.image', true>;
   };


### PR DESCRIPTION
The switch-from-datadog hero needs, per the new design:
  - a row of tech badges (BYOB / OpenTelemetry / Rust) under the title
  - two CTA buttons under the description
  - an image or video where the HubSpot form currently sits

Adds techBadges (elements.button-with-icon), primaryButton/secondaryButton (elements.button, same pattern as hero-v2) and a media field. Existing form fields are left in place so pages without media keep rendering the form.